### PR TITLE
Add a new role for building, using and removing initramfs

### DIFF
--- a/roles/bigboot/defaults/main.yaml
+++ b/roles/bigboot/defaults/main.yaml
@@ -1,4 +1,1 @@
-bigboot_device_name_parameter: extend.device
-bigboot_size_parameter: extend.size
-bigboot_backup_extension: old
 bigboot_size:

--- a/roles/bigboot/tasks/main.yaml
+++ b/roles/bigboot/tasks/main.yaml
@@ -4,13 +4,17 @@
     gather_subset:
     - "!all"
     - "!min"
-    - kernel
     - mounts
 
 - name: Validate bigboot_size is not empty
   ansible.builtin.assert:
     that: bigboot_size | length >0
     fail_msg: "bigboot_size is empty"
+
+- name: Validate initramfs preflight
+  ansible.builtin.include_role:
+    name: initramfs
+    tasks_from: preflight
 
 - name: Find the boot device
   ansible.builtin.set_fact:
@@ -20,17 +24,6 @@
   ansible.builtin.set_fact:
     boot_device_name: "{{ _boot_device.device | regex_replace('[0-9]*', '') }}"
     boot_device_original_size: "{{ _boot_device.size_total | int }}"
-
-- name: Get kernel version
-  ansible.builtin.set_fact:
-    kernel_version: "{{ ansible_facts.kernel }}"
-
-- name: Create a backup of the current initramfs
-  ansible.builtin.copy:
-    remote_src: true
-    src: /boot/initramfs-{{ kernel_version }}.img
-    dest: /boot/initramfs-{{ kernel_version }}.img.{{ bigboot_backup_extension }}
-    mode: "0600"
 
 - name: Copy extend boot dracut module
   ansible.builtin.copy:
@@ -48,25 +41,11 @@
     dest: /usr/lib/dracut/modules.d/99extend_boot/increase-boot-partition.sh
     mode: '0554'
 
-- name: Create a new initramfs with the extend boot module
-  ansible.builtin.command: /usr/sbin/dracut -a extend_boot --kver {{ kernel_version }} --force
-  changed_when: true
-
-- name: Reboot the server
-  ansible.builtin.reboot:
-    post_reboot_delay: 30
-
-- name: Restore previous initramfs
-  ansible.builtin.copy:
-    remote_src: true
-    src: /boot/initramfs-{{ kernel_version }}.img.{{ bigboot_backup_extension }}
-    dest: /boot/initramfs-{{ kernel_version }}.img
-    mode: "0600"
-
-- name: Remove initramfs backup file
-  ansible.builtin.file:
-    path: /boot/initramfs-{{ kernel_version }}.img.{{ bigboot_backup_extension }}
-    state: absent
+- name: Create the initramfs and reboot to run the module
+  vars:
+    initramfs_add_modules: "extend_boot"
+  ansible.builtin.include_role:
+    name: initramfs
 
 - name: Remove dracut extend boot module
   ansible.builtin.file:

--- a/roles/initramfs/defaults/main.yml
+++ b/roles/initramfs/defaults/main.yml
@@ -1,0 +1,3 @@
+initramfs_backup_extension: old
+initramfs_add_modules: ""
+initramfs_post_reboot_delay: 30

--- a/roles/initramfs/tasks/main.yml
+++ b/roles/initramfs/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Make sure the required related facts are available
+  ansible.builtin.setup:
+    gather_subset:
+    - "!all"
+    - "!min"
+    - kernel
+
+- name: Get kernel version
+  ansible.builtin.set_fact:
+    _kernel_version: "{{ ansible_facts.kernel }}"
+
+- name: Create a backup of the current initramfs
+  ansible.builtin.copy:
+    remote_src: true
+    src: /boot/initramfs-{{ _kernel_version }}.img
+    dest: /boot/initramfs-{{ _kernel_version }}.img.{{ initramfs_backup_extension }}
+    mode: "0600"
+
+- name: Create a new initramfs with the extend boot module
+  ansible.builtin.command: '/usr/sbin/dracut {{ ((initramfs_add_modules | length) > 0) | ternary("-a", "") }} "{{ initramfs_add_modules }}" --kver {{ _kernel_version }} --force'
+  changed_when: true
+
+- name: Reboot the server
+  ansible.builtin.reboot:
+    post_reboot_delay: "{{ initramfs_post_reboot_delay }}"
+
+- name: Restore previous initramfs
+  ansible.builtin.copy:
+    remote_src: true
+    src: /boot/initramfs-{{ _kernel_version }}.img.{{ initramfs_backup_extension }}
+    dest: /boot/initramfs-{{ _kernel_version }}.img
+    mode: "0600"
+
+- name: Remove initramfs backup file
+  ansible.builtin.file:
+    path: /boot/initramfs-{{ _kernel_version }}.img.{{ initramfs_backup_extension }}
+    state: absent

--- a/roles/initramfs/tasks/preflight.yml
+++ b/roles/initramfs/tasks/preflight.yml
@@ -1,0 +1,27 @@
+---
+- name: Make sure the required related facts are available
+  ansible.builtin.setup:
+    gather_subset:
+    - "!all"
+    - "!min"
+    - kernel
+
+- name: Get kernel version
+  ansible.builtin.set_fact:
+    _kernel_version: "{{ ansible_facts.kernel }}"
+
+- name: Get default kernel
+  ansible.builtin.command:
+    cmd: /sbin/grubby --default-kernel
+  register: _grubby_rc
+  changed_when: false
+
+- name: Parse default kernel version
+  ansible.builtin.set_fact:
+    _default_kernel: "{{ ((((_grubby_rc.stdout_lines[0] | split('/'))[2] | split('-'))[1:]) | join('-')) | trim }}"
+
+- name: Check the values
+  ansible.builtin.assert:
+    that: _default_kernel == _kernel_version
+    fail_msg: "Current kernel version '{{ _kernel_version }}' is not the default version '{{ _default_kernel }}'"
+    success_msg: "Current kernel version {{ _kernel_version }} and default version {{ _default_kernel }} match"


### PR DESCRIPTION
To allow the reuse of the steps to build, reboot and restore the initramfs move the steps into a dedicated role