### PR TITLE
Support cases in which there is a prefix between the disk and the partition number or no boot flag

### DIFF
--- a/roles/bigboot/tasks/get_boot_device_info.yml
+++ b/roles/bigboot/tasks/get_boot_device_info.yml
@@ -14,5 +14,7 @@
 
 - name: Capture boot device details
   ansible.builtin.set_fact:
+    boot_device_partition_prefix: "{{ _boot_partition_name[(_boot_disk | length):-1] }}"
+    boot_partition_number: "{{ _boot_partition_name[-1] }}"
     boot_device_name: "/dev/{{ _boot_disk }}"
     boot_device_original_size: "{{ _boot_mount_entry.size_total | int }}"

--- a/roles/bigboot/tasks/get_boot_device_info.yml
+++ b/roles/bigboot/tasks/get_boot_device_info.yml
@@ -1,0 +1,18 @@
+- name: Find the boot mount entry
+  ansible.builtin.set_fact:
+    _boot_mount_entry: "{{ ansible_facts.mounts | selectattr('mount', 'equalto', '/boot') | first }}"
+
+- name: Calculate the partition to look for
+  ansible.builtin.set_fact:
+    _boot_partition_name: "{{ (_boot_mount_entry.device | split('/'))[-1] }}"
+
+- name: Find the boot device parent
+  ansible.builtin.set_fact:
+    _boot_disk: "{{ item.key }}"
+  with_dict: "{{ ansible_facts.devices }}"
+  when: _boot_partition_name in item.value.partitions
+
+- name: Capture boot device details
+  ansible.builtin.set_fact:
+    boot_device_name: "/dev/{{ _boot_disk }}"
+    boot_device_original_size: "{{ _boot_mount_entry.size_total | int }}"

--- a/roles/bigboot/tasks/main.yaml
+++ b/roles/bigboot/tasks/main.yaml
@@ -5,6 +5,7 @@
     - "!all"
     - "!min"
     - mounts
+    - devices
 
 - name: Validate bigboot_size is not empty
   ansible.builtin.assert:
@@ -16,14 +17,9 @@
     name: initramfs
     tasks_from: preflight
 
-- name: Find the boot device
-  ansible.builtin.set_fact:
-    _boot_device: "{{ ansible_facts.mounts | selectattr('mount', 'equalto', '/boot') | first }}"
-
-- name: Capture boot device details
-  ansible.builtin.set_fact:
-    boot_device_name: "{{ _boot_device.device | regex_replace('[0-9]*', '') }}"
-    boot_device_original_size: "{{ _boot_device.size_total | int }}"
+- name: Get boot device info
+  ansible.builtin.include_tasks:
+    file: get_boot_device_info.yml
 
 - name: Copy extend boot dracut module
   ansible.builtin.copy:

--- a/roles/bigboot/templates/increase-boot-partition.sh.j2
+++ b/roles/bigboot/templates/increase-boot-partition.sh.j2
@@ -17,7 +17,7 @@ main() {
     start=$(/usr/bin/date +%s)
     disable_lvm_lock
     # run bigboot.sh to increase boot partition and file system size
-    ret=$(sh /usr/bin/bigboot.sh "{{ boot_device_name }}" "{{ bigboot_size }}" 2>/dev/kmsg)
+    ret=$(sh /usr/bin/bigboot.sh -d="{{ boot_device_name }}" -s="{{ bigboot_size }}" -b="{{ boot_partition_number }}" -p="{{ boot_device_partition_prefix }}" 2>/dev/kmsg)
     status=$?
     end=$(/usr/bin/date +%s)
     # write the log file

--- a/roles/initramfs/defaults/main.yml
+++ b/roles/initramfs/defaults/main.yml
@@ -1,3 +1,4 @@
 initramfs_backup_extension: old
 initramfs_add_modules: ""
 initramfs_post_reboot_delay: 30
+initramfs_reboot_timeout: 7200

--- a/roles/initramfs/tasks/main.yml
+++ b/roles/initramfs/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: Reboot the server
   ansible.builtin.reboot:
     post_reboot_delay: "{{ initramfs_post_reboot_delay }}"
+    reboot_timeout: "{{ initramfs_reboot_timeout }}"
 
 - name: Restore previous initramfs
   ansible.builtin.copy:


### PR DESCRIPTION
This PR includes 4 commits. Each commit can live on its own, but together they fix the issue at hand.

1. Find the boot disk from the `devices` list instead of assuming its /dev/<disk><partition_number>
2. shrink.sh cosmetics - whitespaces
3. Change shrink.sh to get the boot partition number as a parameter and support an optional parameter for the prefix. Adjust the role code accordingly
4. Set the reboot timeout to support cases in which it takes more than an hour

Resolves: #5 